### PR TITLE
chore: max to 10 for `RSpec/ExampleLength`. counAsOne for Example and M…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,3 +20,8 @@ and this project adheres to [Semantic Versioning][2].
   environmnets.
 - Enable `NewCops` within `AllCops`.
 - Exclude `db`, `config`, and `script` directories for `AllCops`.
+
+## [0.1.1] - 2025-08-13
+### Added
+- Configuration `Max` for `RSpec/ExampleLength` relaxed to `15`.
+- Configuration `CountAsOne` for `RSpec/ExampleLength` and `Metrics/MethodLength`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,5 +23,5 @@ and this project adheres to [Semantic Versioning][2].
 
 ## [0.2.0] - 2025-08-13
 ### Added
-- Configuration `Max` for `RSpec/ExampleLength` relaxed to `15`.
+- Configuration `Max` for `RSpec/ExampleLength` relaxed to `10`.
 - Configuration `CountAsOne` for `RSpec/ExampleLength` and `Metrics/MethodLength`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning][2].
 - Enable `NewCops` within `AllCops`.
 - Exclude `db`, `config`, and `script` directories for `AllCops`.
 
-## [0.1.1] - 2025-08-13
+## [0.2.0] - 2025-08-13
 ### Added
 - Configuration `Max` for `RSpec/ExampleLength` relaxed to `15`.
 - Configuration `CountAsOne` for `RSpec/ExampleLength` and `Metrics/MethodLength`

--- a/config.yml
+++ b/config.yml
@@ -25,6 +25,11 @@ Metrics/AbcSize:
 
 Metrics/MethodLength:
   Max: 15
+  CountAsOne: [hash, array, method_call]
+
+RSpec/ExampleLength:
+  Max: 15
+  CountAsOne: [hash, array, method_call]
 
 # Rails
 Rails/UnknownEnv:

--- a/config.yml
+++ b/config.yml
@@ -28,7 +28,7 @@ Metrics/MethodLength:
   CountAsOne: [hash, array, method_call, heredoc]
 
 RSpec/ExampleLength:
-  Max: 15
+  Max: 10
   CountAsOne: [hash, array, method_call, heredoc]
 
 # Rails

--- a/config.yml
+++ b/config.yml
@@ -25,11 +25,11 @@ Metrics/AbcSize:
 
 Metrics/MethodLength:
   Max: 15
-  CountAsOne: [hash, array, method_call]
+  CountAsOne: [hash, array, method_call, heredoc]
 
 RSpec/ExampleLength:
   Max: 15
-  CountAsOne: [hash, array, method_call]
+  CountAsOne: [hash, array, method_call, heredoc]
 
 # Rails
 Rails/UnknownEnv:

--- a/platform-rubocop.gemspec
+++ b/platform-rubocop.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name        = 'platform-rubocop'
-  spec.version     = '0.1.1'
+  spec.version     = '0.2.0'
   spec.authors     = ['Rodrigo Vilina']
   spec.email       = ['rodrigovilina@agendapro.com']
 

--- a/platform-rubocop.gemspec
+++ b/platform-rubocop.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name        = 'platform-rubocop'
-  spec.version     = '0.1.0'
+  spec.version     = '0.1.1'
   spec.authors     = ['Rodrigo Vilina']
   spec.email       = ['rodrigovilina@agendapro.com']
 


### PR DESCRIPTION
…ethod length

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * RSpec example length relaxed to 10; hashes, arrays, method calls and heredocs are now counted as single units for example and method length checks.
* **Documentation**
  * Updated changelog with a v0.2.0 entry and removed two previous Unreleased entries.
* **Chores**
  * Bumped package version to v0.2.0; no runtime behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->